### PR TITLE
Pass config through lua function

### DIFF
--- a/lua/nvim-startup/init.lua
+++ b/lua/nvim-startup/init.lua
@@ -1,19 +1,32 @@
-local g = vim.g
+local M = {}
 
--- global variables
-g.nvim_startup_file = g.nvim_startup_file or '/tmp/nvim-startuptime'
+M.setup = function(options)
+    options = options or {
+        startup_file = '/tmp/nvim-startuptime'
+    }
 
-local startup_time_file = io.open(g.nvim_startup_file):read('*all')
-
-if string.len(startup_time_file) > 0 then
     local startup_time_pattern = '([%d.]+)  [%d.]+: [-]+ NVIM STARTED [-]+'
-    local startup_time = startup_time_file:match(startup_time_pattern)
+
+    local startup_time_file = io.open(options.startup_file)
+        and io.open(options.startup_file):read('*all')
+        or nil
+
+    -- "#" is the length operator, can be used on strings or tables
+    local startup_time = startup_time_file
+        and startup_time_file:match(startup_time_pattern)
+        or nil
+
+    if startup_time_file and startup_time then
+        print('nvim-startup: launched in ' .. startup_time .. ' ms')
+    elseif startup_time_file and not startup_time then
+        print('nvim-startup: running on the next (n)vim instance')
+    else
+        print('nvim-startup: startup time log not found (' .. options.startup_file .. ')')
+    end
 
     -- clear startup time log
     -- removing it causes some cache related issues (hyphothesis)
-    io.open(g.nvim_startup_file, 'w'):close()
-
-    print('nvim-startup: launched in ' .. startup_time .. ' ms')
-else
-    print('nvim-startup: running on the next (n)vim instance')
+    io.open(options.startup_file, 'w'):close()
 end
+
+return M


### PR DESCRIPTION
Closes #4 

Quoted from 26423be:

> This allows to a much more unified approach of initializing `nvim-startup`, instead of having global variables scattered between a bunch of different config files, everything goes right on the `.setup()`
function